### PR TITLE
Implemented Recombination Methods

### DIFF
--- a/pyga/utils/recombinations.py
+++ b/pyga/utils/recombinations.py
@@ -1,0 +1,37 @@
+import numpy as np
+from .crossovers import BaseCrossover
+
+
+class LineRecombination(BaseCrossover):
+
+    def __init__(self, p=0.25):
+        self.p = p
+
+        if not self.p > 0:
+            raise ValueError('p must be > 0')
+
+    def cross(self, parent_a, parent_b):
+        lb, ub = parent_a.lb, parent_b.ub
+
+        a = np.random.uniform(-self.p, 1 + self.p)
+        b = np.random.uniform(-self.p, 1 + self.p)
+
+        for i in range(len(parent_a.position)):
+            t = a * parent_a.position[i] + (1 - a) * parent_b.position[i]
+            s = b * parent_b.position[i] + (1 - b) * parent_a.position[i]
+
+            if self._in_bounds(t, lb, ub) and self._in_bounds(s, lb, ub):
+                parent_a.position[i] = t
+                parent_b.position[i] = s
+
+        return parent_a, parent_b
+
+    @staticmethod
+    def _in_bounds(v, lb, ub):
+        return np.logical_and(v >= lb, v <= ub).all()
+
+
+class IntermediateRecombination(BaseCrossover):
+
+    def cross(self, parent_a, parent_b):
+        raise NotImplementedError('IntermediateRecombination::cross()')

--- a/pyga/utils/recombinations.py
+++ b/pyga/utils/recombinations.py
@@ -2,13 +2,26 @@ import numpy as np
 from .crossovers import BaseCrossover
 
 
-class LineRecombination(BaseCrossover):
+class BaseRecombination(BaseCrossover):
 
-    def __init__(self, p=0.25):
+    def __init__(self, p):
         self.p = p
 
         if not self.p > 0:
             raise ValueError('p must be > 0')
+
+    def cross(self, parent_a, parent_b):
+        raise NotImplementedError('BaseRecombination::cross()')
+
+    @staticmethod
+    def _in_bounds(v, lb, ub):
+        return np.logical_and(v >= lb, v <= ub).all()
+
+
+class LineRecombination(BaseRecombination):
+
+    def __init__(self, p=0.25):
+        super().__init__(p)
 
     def cross(self, parent_a, parent_b):
         lb, ub = parent_a.lb, parent_b.ub
@@ -26,12 +39,24 @@ class LineRecombination(BaseCrossover):
 
         return parent_a, parent_b
 
-    @staticmethod
-    def _in_bounds(v, lb, ub):
-        return np.logical_and(v >= lb, v <= ub).all()
 
+class IntermediateRecombination(BaseRecombination):
 
-class IntermediateRecombination(BaseCrossover):
+    def __init__(self, p=0.25):
+        super().__init__(p)
 
     def cross(self, parent_a, parent_b):
-        raise NotImplementedError('IntermediateRecombination::cross()')
+        lb, ub = parent_a.lb, parent_b.ub
+
+        for i in range(len(parent_a.position)):
+            a = np.random.uniform(-self.p, 1 + self.p)
+            b = np.random.uniform(-self.p, 1 + self.p)
+
+            t = a * parent_a.position[i] + (1 - a) * parent_b.position[i]
+            s = b * parent_b.position[i] + (1 - b) * parent_a.position[i]
+
+            if self._in_bounds(t, lb, ub) and self._in_bounds(s, lb, ub):
+                parent_a.position[i] = t
+                parent_b.position[i] = s
+
+        return parent_a, parent_b

--- a/pyga/utils/selections.py
+++ b/pyga/utils/selections.py
@@ -1,7 +1,7 @@
 import abc
 import copy
-import itertools as it
 import numpy as np
+import itertools as it
 
 
 class BaseSelection(abc.ABC):

--- a/tests/utils/test_recombinations.py
+++ b/tests/utils/test_recombinations.py
@@ -1,0 +1,46 @@
+import pytest
+from pyga.individual import Individual
+from pyga.utils.recombinations import *
+
+
+@pytest.fixture
+def parent_a():
+    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+
+@pytest.fixture
+def parent_b():
+    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+
+class TestLineRecombination:
+
+    @pytest.mark.parametrize('p', [-0.25, 0.25])
+    def test_cross(self, parent_a, parent_b, p):
+
+        if p == -0.25:
+            with pytest.raises(ValueError):
+                recombination = LineRecombination(p=p)
+
+        else:
+            recombination = LineRecombination(p=p)
+            ret_a, ret_b = recombination.cross(parent_a, parent_b)
+
+            assert isinstance(ret_a, Individual)
+            assert isinstance(ret_b, Individual)
+
+    @pytest.mark.parametrize('pos', [[25.0, 25.0], [75.0, 25.0], [75.0, 75.0]])
+    def test__in_bounds(self, pos):
+        lb, ub = [0.0, 0.0], [50.0, 50.0]
+        recombination = LineRecombination()
+
+        if pos == [25.0, 25.0]:
+            assert recombination._in_bounds(pos, lb, ub)
+        else:
+            assert not recombination._in_bounds(pos, lb, ub)
+
+
+class TestIntermediateRecombination:
+
+    def test_cross(self):
+        pass

--- a/tests/utils/test_recombinations.py
+++ b/tests/utils/test_recombinations.py
@@ -13,26 +13,16 @@ def parent_b():
     return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
 
 
-class TestLineRecombination:
+class TestBaseRecombination:
 
-    @pytest.mark.parametrize('p', [-0.25, 0.25])
-    def test_cross(self, parent_a, parent_b, p):
-
-        if p == -0.25:
-            with pytest.raises(ValueError):
-                recombination = LineRecombination(p=p)
-
-        else:
-            recombination = LineRecombination(p=p)
-            ret_a, ret_b = recombination.cross(parent_a, parent_b)
-
-            assert isinstance(ret_a, Individual)
-            assert isinstance(ret_b, Individual)
+    def test_init_raise(self):
+        with pytest.raises(ValueError):
+            recombination = BaseRecombination(p=-0.25)
 
     @pytest.mark.parametrize('pos', [[25.0, 25.0], [75.0, 25.0], [75.0, 75.0]])
     def test__in_bounds(self, pos):
         lb, ub = [0.0, 0.0], [50.0, 50.0]
-        recombination = LineRecombination()
+        recombination = BaseRecombination(p=0.25)
 
         if pos == [25.0, 25.0]:
             assert recombination._in_bounds(pos, lb, ub)
@@ -40,7 +30,23 @@ class TestLineRecombination:
             assert not recombination._in_bounds(pos, lb, ub)
 
 
+class TestLineRecombination:
+
+    def test_cross(self, parent_a, parent_b):
+        recombination = LineRecombination()
+        ret_a, ret_b = recombination.cross(parent_a, parent_b)
+
+        assert isinstance(recombination, (BaseRecombination, BaseCrossover))
+        assert isinstance(ret_a, Individual)
+        assert isinstance(ret_b, Individual)
+
+
 class TestIntermediateRecombination:
 
-    def test_cross(self):
-        pass
+    def test_cross(self, parent_a, parent_b):
+        recombination = LineRecombination()
+        ret_a, ret_b = recombination.cross(parent_a, parent_b)
+
+        assert isinstance(recombination, (BaseRecombination, BaseCrossover))
+        assert isinstance(ret_a, Individual)
+        assert isinstance(ret_b, Individual)


### PR DESCRIPTION
## **Recombinations:**

This pull request marks the addition of two recombination methods: ```LineRecombination``` and ```IntermediateRecombination```. Each of these has the same interface as ```BaseCrossover``` so can be used with ease within the optimisation procedure.

It is worth nothing that these classes first inherit from ```BaseRecombination``` which in turn inherits from ```BaseCrossover``` *(```AbstractBaseClass```)* - this ensures all relevant methods are implemented.