### PR TITLE
Bounds now given in dictionary form

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ import pyga
 from pyga.utils.functions import single_objective as fx
 
 
-lb = [-50.0, -50.0]
-ub = [50.0, 50.0]
+bounds = {
+    'x0': [-1e6, 1e6],
+    'x1': [-1e6, 1e6],
+    'x2': [-1e6, 1e6]
+}
 
-optimiser = pyga.SOGA(lb, ub, n_individuals=30, n_iterations=100)
+optimiser = pyga.SOGA(bounds, n_individuals=30, n_iterations=100)
 optimiser.optimise(fx.sphere)
 ```
 

--- a/pyga/individual.py
+++ b/pyga/individual.py
@@ -3,31 +3,46 @@ import numpy as np
 
 class Individual:
 
-    def __init__(self, lb, ub):
+    def __init__(self, bounds):
 
         """
         Class containing information about a population member.
 
         Parameters
         ----------
-        lb : list or np.ndarray
-            Lower bound of the search space.
-        ub : list or np.ndarray
-            Upper bound of the search space.
+        bounds : dict
+            Parameter names mapped to upper / lower bounds.
 
         Attributes
         ----------
+        _pnames : list
+            Names assigned to the input bounds.
         position : np.ndarray
             Current position of the individual.
         fitness : float
             Fitness evaluation for the associated position.
         """
 
-        if len(lb) != len(ub):
-            raise ValueError(f'len(lb): {len(lb)} != len(ub): {len(ub)}')
+        if not isinstance(bounds, dict):
+            raise TypeError('bounds must be dict.')
 
-        self.lb = np.asarray(lb)
-        self.ub = np.asarray(ub)
+        self._pnames = list(bounds.keys())
+        _bounds = np.asarray(list(bounds.values()))
 
-        self.position = np.random.uniform(lb, ub)
+        self.lb = _bounds[:, 0]
+        self.ub = _bounds[:, 1]
+
+        self.position = np.random.uniform(self.lb, self.ub)
         self.fitness = None
+
+    def __str__(self):
+
+        message = 'Position = {\n'
+
+        for k, v in zip(self._pnames, self.position):
+            message += f'\t{k:<15}{v}\n'
+
+        message += '}\n'
+        message += f'\nFitness = {self.fitness}'
+
+        return message

--- a/pyga/soga.py
+++ b/pyga/soga.py
@@ -9,17 +9,15 @@ from .utils.termination_manager import IterationTerminationManager
 
 class SOGA:
 
-    def __init__(self, lb, ub, n_individuals, n_iterations):
+    def __init__(self, bounds, n_individuals, n_iterations):
 
         """
         Single-Objective Genetic Algorithm.
 
         Parameters
         ----------
-        lb : list or np.ndarray
-            Lower bound of the search space.
-        ub : list of np.ndarray
-            Upper bound of the search space.
+        bounds : dict
+            Parameter names mapped to upper / lower bounds.
         n_individuals : int
             Number of individuals in the population.
         n_iterations : int
@@ -27,6 +25,8 @@ class SOGA:
 
         Attributes
         ----------
+        _pnames : list
+            Names assigned to the input bounds.
         iteration : int
             Current iteration of the optimisation process.
         population : list of Individual
@@ -43,14 +43,14 @@ class SOGA:
             Records the history of the optimisation process.
         """
 
-        if len(lb) != len(ub):
-            raise ValueError(f'len(lb): {len(lb)} != len(ub): {len(ub)}')
+        if not isinstance(bounds, dict):
+            raise TypeError('bounds must be dict.')
 
         if not n_individuals % 2 == 0:
             raise ValueError('Please ensure n_individuals is even.')
 
-        self.lb = np.asarray(lb)
-        self.ub = np.asarray(ub)
+        self.bounds = bounds
+        self._pnames = list(bounds.keys())
 
         self.n_individuals = n_individuals
         self.n_iterations = n_iterations
@@ -79,7 +79,7 @@ class SOGA:
         """Generates the population list of Individuals."""
 
         for _ in range(self.n_individuals):
-            self.population.append(Individual(self.lb, self.ub))
+            self.population.append(Individual(self.bounds))
 
     def update_best(self, individual):
 

--- a/pyga/utils/plotting/plotting.py
+++ b/pyga/utils/plotting/plotting.py
@@ -1,7 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
+
 from .plot_designer import PlotDesigner
-from pyga.utils.history import BaseHistory
+from ..history import BaseHistory
 
 
 def plot_fitness_history(history, title, designer=None, save=None):

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -5,21 +5,16 @@ from pyga.individual import Individual
 
 class TestIndividual:
 
-    @pytest.mark.parametrize('ub', [[10, 10], np.array([10, 10])])
-    def test_init(self, ub):
+    def test_init(self):
 
-        lb = [0, 0]
-        individual = Individual(lb, ub)
+        bounds = {
+            'x0': [0, 10],
+            'x1': [0, 10]
+        }
+
+        individual = Individual(bounds)
 
         assert isinstance(individual.lb, np.ndarray)
         assert isinstance(individual.ub, np.ndarray)
         assert isinstance(individual.position, np.ndarray)
         assert individual.fitness is None
-
-    def test_init_raise(self):
-
-        lb = [0, 0]
-        ub = [10, 10, 10]
-
-        with pytest.raises(ValueError):
-            individual = Individual(lb, ub)

--- a/tests/test_soga.py
+++ b/tests/test_soga.py
@@ -8,21 +8,25 @@ class TestSOGA:
     @pytest.fixture
     def soga(self):
 
-        lb = [0.0, 0.0]
-        ub = [10.0, 10.0]
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+        }
+
         n_individuals = 10
         n_iterations = 10
 
-        soga = SOGA(lb, ub, n_individuals, n_iterations)
+        soga = SOGA(bounds, n_individuals, n_iterations)
         return soga
 
     @pytest.fixture
     def individual(self):
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+        }
 
-        lb = [0.0, 0.0]
-        ub = [10.0, 10.0]
-
-        individual = Individual(lb, ub)
+        individual = Individual(bounds)
         individual.fitness = 50.0
 
         return individual
@@ -50,10 +54,12 @@ class TestSOGA:
 
     def test_update_best(self, soga, individual):
 
-        lb = [0.0, 0.0]
-        ub = [10.0, 10.0]
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+        }
 
-        soga.best_individual = Individual(lb, ub)
+        soga.best_individual = Individual(bounds)
         soga.best_individual.fitness = 100.0
 
         soga.update_best(individual)

--- a/tests/utils/test_crossovers.py
+++ b/tests/utils/test_crossovers.py
@@ -5,12 +5,24 @@ from pyga.utils.crossovers import *
 
 @pytest.fixture
 def parent_a():
-    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+    bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+    }
+
+    return Individual(bounds)
 
 
 @pytest.fixture
 def parent_b():
-    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+    bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+    }
+
+    return Individual(bounds)
 
 
 class TestOnePointCrossover:

--- a/tests/utils/test_history.py
+++ b/tests/utils/test_history.py
@@ -9,12 +9,15 @@ class TestGeneralHistory:
     @pytest.fixture
     def soga(self):
 
-        lb = [-10.0, -10.0]
-        ub = [10.0, 10.0]
-        soga = SOGA(lb, ub, n_individuals=30, n_iterations=100)
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+
+        }
+        soga = SOGA(bounds, n_individuals=30, n_iterations=100)
         soga.initialise_population()
 
-        soga.best_individual = Individual(lb, ub)
+        soga.best_individual = Individual(bounds)
         soga.best_individual.fitness = 0.5
 
         for idx, individual in enumerate(soga.population):

--- a/tests/utils/test_recombinations.py
+++ b/tests/utils/test_recombinations.py
@@ -5,12 +5,24 @@ from pyga.utils.recombinations import *
 
 @pytest.fixture
 def parent_a():
-    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+    bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+    }
+
+    return Individual(bounds)
 
 
 @pytest.fixture
 def parent_b():
-    return Individual([0.0, 0.0, 0.0, 0.0], [50.0, 50.0, 50.0, 50.0])
+
+    bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+    }
+
+    return Individual(bounds)
 
 
 class TestBaseRecombination:

--- a/tests/utils/test_selections.py
+++ b/tests/utils/test_selections.py
@@ -8,7 +8,13 @@ def population():
 
     population = []
     for i in range(1, 5 + 1):
-        _ind = Individual([0], [10])
+
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+        }
+
+        _ind = Individual(bounds)
         _ind.fitness = i
         population.append(_ind)
 

--- a/tests/utils/test_termination_manager.py
+++ b/tests/utils/test_termination_manager.py
@@ -7,8 +7,13 @@ from pyga.utils.termination_manager import *
 
 @pytest.fixture
 def ga():
-    lb, ub = [0.0, 0.0], [50.0, 50.0]
-    ga = SOGA(lb, ub, n_individuals=10, n_iterations=100)
+
+    bounds = {
+        'x0': [0.0, 10.0],
+        'x1': [0.0, 10.0]
+    }
+
+    ga = SOGA(bounds, n_individuals=10, n_iterations=100)
     return ga
 
 
@@ -48,7 +53,13 @@ class TestEvaluationTerminationManager:
 class TestErrorTerminationManager:
 
     def test_termination_check(self, ga):
-        best = Individual([0.0, 0.0], [50.0, 50.0])
+
+        bounds = {
+            'x0': [0.0, 10.0],
+            'x1': [0.0, 10.0]
+        }
+
+        best = Individual(bounds)
         best.fitness = 0.0001
         ga.best_individual = best
 


### PR DESCRIPTION
Altered ```Individual``` to make bounds given in dictionary form - this allows the user to provide labels for each of the bounds which can be very useful.

In addition the ```README.md``` has been updated to reflect this change.

All unit tests have been refactored to reflect this change as well.

Resolves: #26